### PR TITLE
support 4k json format

### DIFF
--- a/ChameleonMiniGUI/Json/MifareClassicModel.cs
+++ b/ChameleonMiniGUI/Json/MifareClassicModel.cs
@@ -35,7 +35,7 @@ namespace ChameleonMiniGUI.Json
             get
             {
                 return Enumerable
-                    .Range(0, Blocks.Length / 4)
+                    .Range(0, Blocks.Length <= 128 ? Blocks.Length / 4 : 32 + (Blocks.Length - 128) / 16)
                     .ToDictionary(i => i.ToString(), i => new MifareClassicSectorKey(this, i));
             }
             set { }

--- a/ChameleonMiniGUI/Json/MifareClassicSectorKey.cs
+++ b/ChameleonMiniGUI/Json/MifareClassicSectorKey.cs
@@ -22,12 +22,34 @@ namespace ChameleonMiniGUI.Json
             this.sector = sector;
         }
 
+        int FirstBlockNumber
+        {
+            get
+            {
+                if (sector < 32)
+                    return sector * 4;
+                else
+                    return 32 * 4 + (sector - 32) * 16;
+            }
+        }
+
+        int KeyBlockNumber
+        {
+            get
+            {
+                if (sector < 32)
+                    return sector * 4 + 3;
+                else
+                    return 32 * 4 + (sector - 32) * 16 + 15;
+            }
+        }
+
         [DataMember(Order = 0)]
         public string KeyA
         {
             get
             {
-                return MifareClassicModel.ByteArrayToString(mfc.Blocks[sector * 4 + 3].Take(6));
+                return MifareClassicModel.ByteArrayToString(mfc.Blocks[KeyBlockNumber].Take(6));
             }
             set { }
         }
@@ -37,7 +59,7 @@ namespace ChameleonMiniGUI.Json
         {
             get
             {
-                return MifareClassicModel.ByteArrayToString(mfc.Blocks[sector * 4 + 3].Skip(10).Take(6));
+                return MifareClassicModel.ByteArrayToString(mfc.Blocks[KeyBlockNumber].Skip(10).Take(6));
             }
             set { }
         }
@@ -47,9 +69,17 @@ namespace ChameleonMiniGUI.Json
         {
             get
             {
-                return MifareClassicModel.ByteArrayToString(mfc.Blocks[sector * 4 + 3].Skip(6).Take(4));
+                return MifareClassicModel.ByteArrayToString(mfc.Blocks[KeyBlockNumber].Skip(6).Take(4));
             }
             set { }
+        }
+
+        string GetBlockNameByConditionNumber(int i)
+        {
+            var start = FirstBlockNumber;
+            if (sector < 32)
+                return "block" + (start + i);
+            return $"block{start + i * 5}~block{start + i * 5 + 4}";
         }
 
         [DataMember(Order = 3)]
@@ -57,14 +87,14 @@ namespace ChameleonMiniGUI.Json
         {
             get
             {
-                var keyBlock = mfc.Blocks[sector * 4 + 3];
+                var keyBlock = mfc.Blocks[KeyBlockNumber];
                 var conditions = keyBlock.Skip(6).Take(4).ToArray();
                 var dic = new Dictionary<string, string>
                 {
-                    ["block" + (sector * 4)] = GetAccessConditionsDesc(0, conditions),
-                    ["block" + (sector * 4 + 1)] = GetAccessConditionsDesc(1, conditions),
-                    ["block" + (sector * 4 + 2)] = GetAccessConditionsDesc(2, conditions),
-                    ["block" + (sector * 4 + 3)] = GetAccessConditionsDesc(3, conditions),
+                    [GetBlockNameByConditionNumber(0)] = GetAccessConditionsDesc(0, conditions),
+                    [GetBlockNameByConditionNumber(1)] = GetAccessConditionsDesc(1, conditions),
+                    [GetBlockNameByConditionNumber(2)] = GetAccessConditionsDesc(2, conditions),
+                    ["block" + KeyBlockNumber] = GetAccessConditionsDesc(3, conditions),
                     ["UserData"] = MifareClassicModel.ByteArrayToString(keyBlock.Skip(9).Take(1))
                 };
                 return dic;


### PR DESCRIPTION
I think RRG proxmark3 only support 1k json dump.
https://github.com/RfidResearchGroup/proxmark3/blob/898484f642aed5ad696690728431bd4419ccce7d/client/loclass/fileutils.c#L164

So I follow mifare S70 document. Made this format.
```
    "32": {
      "KeyA": "FFFFFFFFFFFF",
      "KeyB": "FFFFFFFFFFFF",
      "AccessConditions": "FF078069",
      "AccessConditionsText": {
        "block128~block132": "rdAB wrAB incAB dectrAB",
        "block133~block137": "rdAB wrAB incAB dectrAB",
        "block138~block142": "rdAB wrAB incAB dectrAB",
        "block143": "wrAbyA rdCbyA wrCbyA rdBbyA wrBbyA",
        "UserData": "69"
      }
    },
```
full json https://pastebin.com/wdRZ7KiX