### PR TITLE
Integrates firmware memory rewrite

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -146,7 +146,7 @@ namespace ChameleonMiniGUI
             else
             {
                 // set the default value
-                // should be a setting aswell 
+                // should be a setting aswell
                 txt_interval.Text = "2000";
             }
 
@@ -289,7 +289,7 @@ namespace ChameleonMiniGUI
                         {
                             FindControls<ComboBox>(Controls, $"cb_Lbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON{_cmdExtension}={a.SelectedItem}"));
                             FindControls<ComboBox>(Controls, $"cb_Lbuttonlong{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON_LONG{_cmdExtension}={a.SelectedItem}"));
-                            FindControls<ComboBox>(Controls, $"cb_Rbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON{_cmdExtension}={a.SelectedItem}"));                            
+                            FindControls<ComboBox>(Controls, $"cb_Rbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON{_cmdExtension}={a.SelectedItem}"));
                             FindControls<ComboBox>(Controls, $"cb_Rbuttonlong{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON_LONG{_cmdExtension}={a.SelectedItem}"));
                             FindControls<ComboBox>(Controls, $"cb_ledgreen{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDGREEN{_cmdExtension}={a.SelectedItem}"));
                             FindControls<ComboBox>(Controls, $"cb_ledred{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDRED{_cmdExtension}={a.SelectedItem}"));
@@ -428,7 +428,7 @@ namespace ChameleonMiniGUI
         {
             this.Cursor = Cursors.WaitCursor;
             SaveActiveSlot();
-                
+
             var downloadPath = Application.StartupPath;
 
             // Try to use the default download path if exists
@@ -551,12 +551,12 @@ namespace ChameleonMiniGUI
 
                 var tagslotIndex = int.Parse(cb.Name.Substring(cb.Name.Length - 1));
                 if (tagslotIndex <= 0) continue;
-                
+
                 SendCommandWithoutResult($"SETTING{_cmdExtension}={tagslotIndex - _tagslotIndexOffset}");
                 SendCommandWithoutResult($"CLEAR{_cmdExtension}");
 
                 // Set every field to a default value
-                
+
                 FindControls<ComboBox>(Controls, $"cb_mode{tagslotIndex}").ForEach( a => SendCommandWithoutResult($"CONFIG{_cmdExtension}=CLOSED"));
 
                 switch (_CurrentDevType)
@@ -565,7 +565,7 @@ namespace ChameleonMiniGUI
                     {
                         FindControls<ComboBox>(Controls, $"cb_Lbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_Lbuttonlong{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON_LONG{_cmdExtension}={a.Items[0]}"));
-                        FindControls<ComboBox>(Controls, $"cb_Rbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON{_cmdExtension}={a.Items[0]}"));                                
+                        FindControls<ComboBox>(Controls, $"cb_Rbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_Rbuttonlong{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON_LONG{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_ledgreen{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDGREEN{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_ledred{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDRED{_cmdExtension}={a.Items[0]}"));
@@ -575,7 +575,7 @@ namespace ChameleonMiniGUI
                     {
                         FindControls<ComboBox>(Controls, $"cb_Lbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"BUTTON{_cmdExtension}=SWITCHCARD"));
                         FindControls<ComboBox>(Controls, $"cb_Lbuttonlong{tagslotIndex}").ForEach( a =>
-                        { 
+                        {
                             if (a.Items.Count > 0)
                             {
                                 SendCommandWithoutResult($"BUTTON_LONG{_cmdExtension}={a.Items[0]}");
@@ -858,7 +858,7 @@ namespace ChameleonMiniGUI
             }
             hexBox1.Focus();
         }
-        
+
         private void byteWidthCheckBoxes_CheckedChanged(object sender, EventArgs e)
         {
             var rb = sender as RadioButton;
@@ -1020,7 +1020,7 @@ namespace ChameleonMiniGUI
             SendCommandWithoutResult($"CONFIG{_cmdExtension}=ISO14443A_READER");
 
             var s = SendCommandWithMultilineResponse($"IDENTIFY{_cmdExtension}").ToString();
-            txt_output.Text += $"{s}{Environment.NewLine}"; 
+            txt_output.Text += $"{s}{Environment.NewLine}";
 
             RestoreActiveSlot();
             this.Cursor = Cursors.Default;
@@ -1720,8 +1720,6 @@ namespace ChameleonMiniGUI
                         var cbMode = FindControls<ComboBox>(Controls, $"cb_mode{slotIndex}");
                         foreach (var box in cbMode)
                         {
-                            if (slotMode.Equals("MF_CLASSIC_4K") && box.Name != "cb_mode1")
-                                continue;
                             box.SelectedItem = slotMode;
                         }
                     }
@@ -1938,12 +1936,6 @@ namespace ChameleonMiniGUI
                     {
                         cb.Items.Clear();
                         cb.Items.AddRange(_modesArray);
-
-                        // We can set the MF_CLASSIC_4K mode only on the first tag slot
-                        if (cb.Name != "cb_mode1")
-                        {
-                            cb.Items.Remove("MF_CLASSIC_4K");
-                        }
                     }
                 }
             }
@@ -1998,7 +1990,7 @@ namespace ChameleonMiniGUI
                 case DeviceType.RevG:
                     SetRevGButtons();
                     break;
-                case DeviceType.RevE:                
+                case DeviceType.RevE:
                     SetRevEButtons();
                     break;
             }
@@ -2163,7 +2155,7 @@ namespace ChameleonMiniGUI
 
             // Then send the download command
             SendCommandWithoutResult($"DOWNLOAD{_cmdExtension}");
-            
+
             // For the "110:WAITING FOR XMODEM" text
             _comport.ReadLine();
 
@@ -2656,7 +2648,7 @@ namespace ChameleonMiniGUI
         }
 
         /// <summary>
-        /// save the active slot.  Use before all 
+        /// save the active slot.  Use before all
         /// </summary>
         private bool SaveActiveSlot()
         {
@@ -2680,7 +2672,7 @@ namespace ChameleonMiniGUI
             // Check if saved active slot is within the limit (0...7)
             if (_active_selected_slot < _tagslotIndexOffset) _active_selected_slot = _tagslotIndexOffset;
             if (_active_selected_slot > _tagslotIndexOffset+7) _active_selected_slot = _tagslotIndexOffset+7;
-            
+
             SendCommandWithoutResult($"SETTING{_cmdExtension}={_active_selected_slot - _tagslotIndexOffset}");
             HighlightActiveSlot();
         }

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -46,6 +46,7 @@ namespace ChameleonMiniGUI
 
         private const int REVGDefaultComboWidth = 80;
         private const int REVEDefaultComboWidth = 175;
+        private const int SerialRWTimeoutMs = 10000;
 
         private bool lockFlag = false;
         private DeviceType _CurrentDevType = DeviceType.RevG;
@@ -1284,8 +1285,8 @@ namespace ChameleonMiniGUI
 
                 _comport = new SerialPort(comPortStr, 115200)
                 {
-                    ReadTimeout = 4000,
-                    WriteTimeout = 6000,
+                    ReadTimeout = SerialRWTimeoutMs,
+                    WriteTimeout = SerialRWTimeoutMs,
                     DtrEnable = true,
                     RtsEnable = true,
                 };

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -560,6 +560,7 @@ namespace ChameleonMiniGUI
             if ((_CurrentDevType == DeviceType.RevE) && (selectedCheckBoxes.Count == allSlotsCheckBoxes.Count) && AvailableCommands.Contains("CLEARALL"))
             {
                 SendCommandWithoutResult($"CLEARALL");
+                RefreshAllSlots();
             }
             // Else we clear all selected slots one by one
             else
@@ -569,7 +570,8 @@ namespace ChameleonMiniGUI
                     var tagslotIndex = int.Parse(cb.Name.Substring(cb.Name.Length - 1));
                     if (tagslotIndex <= 0) continue;
 
-                    SendCommandWithoutResult($"SETTING{_cmdExtension}={tagslotIndex - _tagslotIndexOffset}");
+                    int slotIndex = tagslotIndex - _tagslotIndexOffset;
+                    SendCommandWithoutResult($"SETTING{_cmdExtension}={slotIndex}");
                     SendCommandWithoutResult($"CLEAR{_cmdExtension}");
 
                     // The firmware of RevE-rebooted will deal with proper init to defaults after CLEAR/CLEARALL command
@@ -584,11 +586,11 @@ namespace ChameleonMiniGUI
                         FindControls<ComboBox>(Controls, $"cb_ledgreen{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDGREEN{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_ledred{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDRED{_cmdExtension}={a.Items[0]}"));
                     }
+                    RefreshSlot(slotIndex);
                 }
             }
 
             RestoreActiveSlot();
-            RefreshAllSlots();
 
             this.Cursor = Cursors.Default;
         }


### PR DESCRIPTION
In order to keep GUI in sync we recent firmware changes:
- remove the limitation of MF 4K availability in 1st slot only
- tune some timeouts in order to allow some longer commands to run
- automatically erase all memory at once with RevE rebooted instead of all slots one by one if all are selected
- fix the GUI messing with firmware's default configuration settings or UIDs

There might still be an issue with KeepAlive and manually set Serial commands somehow conflicting, that would not be tied to recent changes. Will see if that actually exists in issues : )