### PR TITLE
Fix double slot refresh on "Apply", and wrong "Clear" slot refresh index

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -308,7 +308,7 @@ namespace ChameleonMiniGUI
                 var txtUid = FindControls<TextBox>(Controls, $"txt_uid{tagslotIndex}").FirstOrDefault();
                 if (txtUid != null)
                 {
-                    string oldUid = SendCommand($"UID{_cmdExtension}?").ToString();
+                    string fwSetUid = SendCommand($"UID{_cmdExtension}?").ToString();
                     string uid = txtUid.Text;
                     uint uidSize = uint.Parse(SendCommand($"UIDSIZE{_cmdExtension}?").ToString());
                     // Sets UID if valid only
@@ -316,8 +316,12 @@ namespace ChameleonMiniGUI
                     {
                         if(!SendCommand($"UID{_cmdExtension}={uid}").ToString().StartsWith("101"))
                         {
-                            txtUid.Text = oldUid;
+                            txtUid.Text = fwSetUid;
                         }
+                    }
+                    else 
+                    {
+                        txtUid.Text = fwSetUid;
                     }
                 }
 
@@ -327,8 +331,6 @@ namespace ChameleonMiniGUI
                 {
                     FindControls<TextBox>(Controls, $"txt_size{tagslotIndex}").ForEach(a => a.Text = slotMemSize);
                 }
-
-                RefreshSlot(tagslotIndex);
             }
             RestoreActiveSlot();
 
@@ -582,7 +584,7 @@ namespace ChameleonMiniGUI
                         FindControls<ComboBox>(Controls, $"cb_ledgreen{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDGREEN{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_ledred{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDRED{_cmdExtension}={a.Items[0]}"));
                     }
-                    RefreshSlot(slotIndex);
+                    RefreshSlot(tagslotIndex);
                 }
             }
 

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -46,7 +46,8 @@ namespace ChameleonMiniGUI
 
         private const int REVGDefaultComboWidth = 80;
         private const int REVEDefaultComboWidth = 175;
-        private const int SerialRWTimeoutMs = 10000;
+        private const int SerialRTimeoutMs = 4000;
+        private const int SerialWTimeoutMs = 10000;
 
         private bool lockFlag = false;
         private DeviceType _CurrentDevType = DeviceType.RevG;
@@ -1284,8 +1285,8 @@ namespace ChameleonMiniGUI
 
                 _comport = new SerialPort(comPortStr, 115200)
                 {
-                    ReadTimeout = SerialRWTimeoutMs,
-                    WriteTimeout = SerialRWTimeoutMs,
+                    ReadTimeout = SerialRTimeoutMs,
+                    WriteTimeout = SerialWTimeoutMs,
                     DtrEnable = true,
                     RtsEnable = true,
                 };

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -314,7 +314,7 @@ namespace ChameleonMiniGUI
                     // Sets UID if valid only
                     if (!string.IsNullOrEmpty(uid) && !string.IsNullOrEmpty(selectedMode) && IsUidValid(uid, uidSize, selectedMode))
                     {
-                        if(!SendCommand($"UID{_cmdExtension}={uid}").ToString().StartsWith("101"))
+                        if (SendCommand($"UID{_cmdExtension}={uid}").ToString() != "")
                         {
                             txtUid.Text = fwSetUid;
                         }


### PR DESCRIPTION
- Fix slot refresh on bad index (was fw index, and not text/GUI index) when "Clear" pushed, which caused bad GUI slot switching;
- Fix double slot refresh when pushing "Apply" (due to calling a function that would do again what "Apply" already did), which caused much delay.