### PR TITLE
Sendcommand timeoutfix

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -1461,14 +1461,24 @@ namespace ChameleonMiniGUI
                 }
                 else
                 {
-                    var read_response = string.Empty;
-                    var start = DateTime.Now;
+                    string read_response = string.Empty;
+                    string read_response_line = string.Empty;
 
-                    while (((read_response == "") || (read_response == null)) && (DateTime.Now.Subtract(start).TotalMilliseconds < 1000))
+                    try
                     {
-                        read_response = _comport.ReadLine();
-                        read_response = read_response.Replace("101:OK WITH TEXT", "").Replace("100:OK", "").Replace("\r", "");
+                        while (string.IsNullOrEmpty(read_response))
+                        {
+                            read_response_line = _comport.ReadLine();
+                            read_response_line = read_response_line.Replace("101:OK WITH TEXT", "").Replace("100:OK", "").Replace("\r", "");
+                            read_response += read_response_line;
+                        }
                     }
+                    catch(TimeoutException ex)
+                    {
+                        var msg = $"{Environment.NewLine}[!] {ex.Message}{Environment.NewLine}";
+                        txt_output.Text += msg;
+                    }
+                    
                     return read_response;
                 }
             }

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -414,7 +414,7 @@ namespace ChameleonMiniGUI
                     UploadDump(dumpFilename);
 
                     // Refresh slot
-                    RefreshSlot(tagslotIndex);
+                    RefreshSlot(tagslotIndex, false);
                 }
 
                 break; // We can only upload a single dump at a time
@@ -542,7 +542,6 @@ namespace ChameleonMiniGUI
         private void btn_clear_Click(object sender, EventArgs e)
         {
             this.Cursor = Cursors.WaitCursor;
-            SaveActiveSlot();
 
             // Get all selected checkboxes
             List<CheckBox> selectedCheckBoxes = new List<CheckBox>();
@@ -564,6 +563,7 @@ namespace ChameleonMiniGUI
             // Else we clear all selected slots one by one
             else
             {
+                SaveActiveSlot();
                 foreach (var cb in selectedCheckBoxes)
                 {
                     var tagslotIndex = int.Parse(cb.Name.Substring(cb.Name.Length - 1));
@@ -585,11 +585,10 @@ namespace ChameleonMiniGUI
                         FindControls<ComboBox>(Controls, $"cb_ledgreen{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDGREEN{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(Controls, $"cb_ledred{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LEDRED{_cmdExtension}={a.Items[0]}"));
                     }
-                    RefreshSlot(tagslotIndex);
+                    RefreshSlot(tagslotIndex, false);
                 }
+                RestoreActiveSlot();
             }
-
-            RestoreActiveSlot();
 
             this.Cursor = Cursors.Default;
         }
@@ -1608,15 +1607,17 @@ namespace ChameleonMiniGUI
 
         private void RefreshAllSlots()
         {
+            SaveActiveSlot();
             for (int i = 1; i < 9; i++)
             {
-                RefreshSlot(i);
+                RefreshSlot(i, false);
             }
+            RestoreActiveSlot();
         }
 
-        private void RefreshSlot(int slotIndex)
+        private void RefreshSlot(int slotIndex, bool doSaveActive = true)
         {
-            SaveActiveSlot();
+            if(doSaveActive) SaveActiveSlot();
 
             //SETTINGMY=i
             SendCommandWithoutResult($"SETTING{_cmdExtension}={slotIndex - _tagslotIndexOffset}");
@@ -1731,7 +1732,7 @@ namespace ChameleonMiniGUI
                     break;
                 }
             }
-            RestoreActiveSlot();
+            if(doSaveActive) RestoreActiveSlot();
         }
 
         private bool IsLButtonModeValid(string s)


### PR DESCRIPTION
Chasing #111 slowness sources, I discovered that I used a SendCommand instead of SendCommandWithoutResult to set UID in GUI with "Apply".
This introduced many delay, because the "SendCommand" used to get its result data in an possible infinite loop: SendCommand looped on serial ReadLine while received string was empty, but was also emptying strings from all return codes from FW. As so, using "SendCommand" with a command that just returned a standard code looped indefinitely, until a manually set timeout triggered.
Removing this bad timeout trick, that was by the way overloading the original "timeout" settings from the SerialPort, I also discovered the SendCommandWithoutResult was not catching standard return codes (because most if not all command have at least a return code as a result...), which were then popping on read serial buffers from time to time, making the SendCommand logic deal with data from nowhere. Fixed.

That main point, plus some "active slot restore" and UID read factoring, make the GUI dialogue with Chameleon more responsive.