### PR TITLE
Serial timeouts fix

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -1434,7 +1434,7 @@ namespace ChameleonMiniGUI
             }
             catch (Exception ex)
             {
-                var msg = $"{Environment.NewLine}[!] {ex.Message}{Environment.NewLine}";
+                var msg = $"{Environment.NewLine}[!] {cmdText}: {ex.Message}{Environment.NewLine}";
                 txt_output.Text += msg;
                 return false;
             }
@@ -1478,7 +1478,7 @@ namespace ChameleonMiniGUI
                     }
                     catch(TimeoutException ex)
                     {
-                        var msg = $"{Environment.NewLine}[!] {ex.Message}{Environment.NewLine}";
+                        var msg = $"{Environment.NewLine}[!] {cmdText}: {ex.Message}{Environment.NewLine}";
                         txt_output.Text += msg;
                     }
                     


### PR DESCRIPTION
Adapt serial timeouts for GUI to longer one only when needed (long FW commands), now manual timeout in the way has been fixed.
Restore serial timeouts to original GUI ones for all other cases.