### PR TITLE
Added formatted output for RevG LOGDOWNLOAD command in Serial tab

### DIFF
--- a/ChameleonMiniGUI/ChameleonMiniGUI.csproj
+++ b/ChameleonMiniGUI/ChameleonMiniGUI.csproj
@@ -147,6 +147,8 @@
     <Compile Include="Legend\UcLegend.Designer.cs">
       <DependentUpon>UcLegend.cs</DependentUpon>
     </Compile>
+    <Compile Include="Log\LogEntryType.cs" />
+    <Compile Include="Log\LogEntryUtils.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MultiLanguage.cs" />

--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -89,6 +89,8 @@ namespace ChameleonMiniGUI
 
         private List<string> AvailableCommands { get; set; }
 
+        private List<string> ErrorResponses = new List<string>(new string[] { "200:UNKNOWN COMMAND", "201:INVALID COMMAND USAGE", "202:INVALID PARAMETER", "203:TIMEOUT" });
+
         public frm_main()
         {
             InitializeComponent();
@@ -690,6 +692,8 @@ namespace ChameleonMiniGUI
                 btn_keycalc.Enabled = true;
                 btn_upload.Enabled = true;
                 btn_download.Enabled = true;
+                if (_CurrentDevType == DeviceType.RevG)
+                    btn_identify.Enabled = true;
             }
             else if (checkCount > 1)
             {
@@ -701,6 +705,7 @@ namespace ChameleonMiniGUI
                 btn_keycalc.Enabled = true;
                 btn_upload.Enabled = false;
                 btn_download.Enabled = true;
+                btn_identify.Enabled = false;
             }
             else
             {
@@ -1436,7 +1441,7 @@ namespace ChameleonMiniGUI
                 {
                     string retCode = _comport.ReadLine();
                     // If we get an error
-                    if (!retCode.StartsWith("1"))
+                    if (ErrorResponses.Any(s => retCode.Contains(s)))
                     {
                         throw new Exception(cmdText + "returned: " + retCode.Replace("\r", ""));
                     }
@@ -1593,6 +1598,11 @@ namespace ChameleonMiniGUI
                     var hex = new StringBuilder(result.Length * 2);
                     hex.Append($"{Environment.NewLine}");
                     var counter = 0;
+
+                    if (cmdText.Contains($"LOGDOWNLOAD{_cmdExtension}"))
+                    {
+                        return Log.LogEntryUtils.ParseDownloadedLog(result);
+                    }
 
                     foreach (var b in result)
                     {

--- a/ChameleonMiniGUI/Log/LogEntryType.cs
+++ b/ChameleonMiniGUI/Log/LogEntryType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChameleonMiniGUI.Log
+{
+    public enum LogEntryType
+    {
+        LOG_INFO_GENERIC = 0x10, // Unspecific log entry.
+        LOG_INFO_CONFIG_SET = 0x11, // Configuration change.
+        LOG_INFO_SETTING_SET = 0x12, // Setting change.
+        LOG_INFO_UID_SET = 0x13, // UID change.
+        LOG_INFO_RESET_APP = 0x20, // Application reset.
+
+        /* Codec */
+        LOG_INFO_CODEC_RX_DATA = 0x40, // Currently active codec received data.
+        LOG_INFO_CODEC_TX_DATA = 0x41, // Currently active codec sent data.
+        LOG_INFO_CODEC_RX_DATA_W_PARITY = 0x42, // Currently active codec received data.
+        LOG_INFO_CODEC_TX_DATA_W_PARITY = 0x43, // Currently active codec sent data.
+
+        LOG_INFO_CODEC_SNI_READER_DATA = 0x44, // Sniffing codec receive data from reader
+        LOG_INFO_CODEC_SNI_READER_DATA_W_PARITY = 0x45, // Sniffing codec receive data from reader
+
+        LOG_INFO_CODEC_SNI_CARD_DATA = 0x46, // Sniffing codec receive data from card
+        LOG_INFO_CODEC_SNI_CARD_DATA_W_PARITY = 0x47, // Sniffing codec receive data from card
+
+        /* App */
+        LOG_INFO_APP_CMD_READ = 0x80, // Application processed read command.
+        LOG_INFO_APP_CMD_WRITE = 0x81, // Application processed write command.
+        LOG_INFO_APP_CMD_INC = 0x84, // Application processed increment command.
+        LOG_INFO_APP_CMD_DEC = 0x85, // Application processed decrement command.
+        LOG_INFO_APP_CMD_TRANSFER = 0x86, // Application processed transfer command.
+        LOG_INFO_APP_CMD_RESTORE = 0x87, // Application processed restore command.
+        LOG_INFO_APP_CMD_AUTH = 0x90, // Application processed authentication command.
+        LOG_INFO_APP_CMD_HALT = 0x91, // Application processed halt command.
+        LOG_INFO_APP_CMD_UNKNOWN = 0x92, // Application processed an unknown command.
+        LOG_INFO_APP_AUTHING = 0xA0, // Application is in `authing` state.
+        LOG_INFO_APP_AUTHED = 0xA1, // Application is in `auth` state.
+        LOG_ERR_APP_AUTH_FAIL = 0xC0, // Application authentication failed.
+        LOG_ERR_APP_CHECKSUM_FAIL = 0xC1, // Application had a checksum fail.
+        LOG_ERR_APP_NOT_AUTHED = 0xC2, // Application is not authenticated.
+
+        LOG_INFO_SYSTEM_BOOT = 0xFF, // Chameleon boots
+
+        LOG_EMPTY = 0x00  // Empty Log Entry. This is not followed by a length byte nor the two systick bytes nor any data.
+    }
+}

--- a/ChameleonMiniGUI/Log/LogEntryUtils.cs
+++ b/ChameleonMiniGUI/Log/LogEntryUtils.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+namespace ChameleonMiniGUI.Log
+{
+    class LogEntryUtils
+    {
+
+        public static string ParseDownloadedLog(byte[] result)
+        {
+            var s = "";
+            var result_size = result.Length;
+            var idx = 0;
+
+            while (idx <= result_size)
+            {
+                if (idx + 4 > result_size)
+                    break;
+
+                var entry_type = result[idx++];
+                var data_length = result[idx++];
+                var timestampArray = new byte[] { result[idx++], result[idx++] };
+                int timestamp = (((int)timestampArray[0]) << 8) | ((int)timestampArray[1]);
+
+                if ((data_length > 0) && (idx + data_length <= result_size))
+                {
+                    byte[] data = new byte[data_length];
+                    Array.Copy(result, idx, data, 0, data_length);
+                    idx += data_length;
+                    s += "[" + timestamp + "] " + ParseLogEntry(entry_type, data);
+                }
+            }
+
+            return s;
+        }
+
+        private static string ParseLogEntry(byte entry_type, byte[] data)
+        {
+            switch (entry_type)
+            {
+                case (byte)LogEntryType.LOG_INFO_CONFIG_SET:
+                    var configStr = System.Text.Encoding.ASCII.GetString(data);
+                    return "CONFIG SET: " + configStr + Environment.NewLine;
+                case (byte)LogEntryType.LOG_INFO_SETTING_SET:
+                    var settingNr = data[0] - '0';
+                    return "SETTING SET: " + settingNr + Environment.NewLine;
+                case (byte)LogEntryType.LOG_INFO_GENERIC:
+                case (byte)LogEntryType.LOG_INFO_UID_SET:
+                case (byte)LogEntryType.LOG_INFO_RESET_APP:
+                case (byte)LogEntryType.LOG_INFO_CODEC_RX_DATA:
+                case (byte)LogEntryType.LOG_INFO_CODEC_TX_DATA:
+                case (byte)LogEntryType.LOG_INFO_CODEC_RX_DATA_W_PARITY:
+                case (byte)LogEntryType.LOG_INFO_CODEC_TX_DATA_W_PARITY:
+                case (byte)LogEntryType.LOG_INFO_CODEC_SNI_READER_DATA:
+                case (byte)LogEntryType.LOG_INFO_CODEC_SNI_READER_DATA_W_PARITY:
+                case (byte)LogEntryType.LOG_INFO_CODEC_SNI_CARD_DATA:
+                case (byte)LogEntryType.LOG_INFO_CODEC_SNI_CARD_DATA_W_PARITY:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_READ:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_WRITE:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_INC:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_DEC:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_TRANSFER:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_RESTORE:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_AUTH:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_HALT:
+                case (byte)LogEntryType.LOG_INFO_APP_CMD_UNKNOWN:
+                case (byte)LogEntryType.LOG_INFO_APP_AUTHING:
+                case (byte)LogEntryType.LOG_INFO_APP_AUTHED:
+                case (byte)LogEntryType.LOG_INFO_SYSTEM_BOOT:
+                    return ((LogEntryType)entry_type).ToString().Replace("LOG_INFO_", "").Replace("_", " ") + ": " + BitConverter.ToString(data).Replace("-", " ") + Environment.NewLine;
+                case (byte)LogEntryType.LOG_ERR_APP_AUTH_FAIL:
+                case (byte)LogEntryType.LOG_ERR_APP_CHECKSUM_FAIL:
+                case (byte)LogEntryType.LOG_ERR_APP_NOT_AUTHED:
+                    return ((LogEntryType)entry_type).ToString().Replace("LOG_ERR_", "").Replace("_", " ") + ": " + BitConverter.ToString(data).Replace("-", " ") + Environment.NewLine;
+                default:
+                    return entry_type.ToString("X2") + BitConverter.ToString(data).Replace(" -", " ") + Environment.NewLine;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Each log entry is printed in a separate line, with a timestamp and a user-friendly entry type identification. Most of the payloads are left in their hexadecimal values. No annotation of the RX/TX data for the time being.