### PR TITLE
Correction of the clear function for RevG devices

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -709,7 +709,7 @@ namespace ChameleonMiniGUI
                     // For RevG, we manually set default values
                     if (_CurrentDevType == DeviceType.RevG)
                     {
-                        FindControls<ComboBox>(tpOperation.Controls, $"cb_mode{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"CONFIG{_cmdExtension}=CLOSED"));
+                        FindControls<ComboBox>(tpOperation.Controls, $"cb_mode{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"CONFIG{_cmdExtension}=NONE"));
                         FindControls<ComboBox>(tpOperation.Controls, $"cb_Lbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(tpOperation.Controls, $"cb_Lbuttonlong{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"LBUTTON_LONG{_cmdExtension}={a.Items[0]}"));
                         FindControls<ComboBox>(tpOperation.Controls, $"cb_Rbutton{tagslotIndex}").ForEach(a => SendCommandWithoutResult($"RBUTTON{_cmdExtension}={a.Items[0]}"));


### PR DESCRIPTION
Correction of the default value for CONFIG command for RevG clear functionChange the setting arg of the clear command for RevG devices