### PR TITLE
Add iClass dump detection (2k, as well as default AA1 only dump size)

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -2375,6 +2375,10 @@ namespace ChameleonMiniGUI
                 case 164:
                     SendCommandWithoutResult($"CONFIG{_cmdExtension}=MF_ULTRALIGHT_EV1_164B");
                     break;
+                case 256:
+                case 152:
+                    SendCommandWithoutResult($"CONFIG{_cmdExtension}=ICLASS");
+                    break;
                 // case for NTAG21X
                 case 180:
                     SendCommandWithoutResult($"CONFIG{_cmdExtension}=NTAG213");
@@ -2385,9 +2389,11 @@ namespace ChameleonMiniGUI
                 case 924:
                     SendCommandWithoutResult($"CONFIG{_cmdExtension}=NTAG216");
                     break;
-                // default to m1
-                default:
+                case 1024:
                     SendCommandWithoutResult(IdentifyUIDSize(dump.Data) == 7 ? $"CONFIG{_cmdExtension}=MF_CLASSIC_1K_7B" : $"CONFIG{_cmdExtension}=MF_CLASSIC_1K");
+                    break;
+                default:
+                    //SendCommandWithoutResult(IdentifyUIDSize(dump.Data) == 7 ? $"CONFIG{_cmdExtension}=MF_CLASSIC_1K_7B" : $"CONFIG{_cmdExtension}=MF_CLASSIC_1K");
                     break;
             }
         }


### PR DESCRIPTION
Basic iClass support. Works for 2k full size dumps and iClass AA1 only dumps.

Also changes the behaviour for unknown sized dumps to not change the selected type rather than defaulting to always to mifare classic. This should make it easier in the future to support new card types (select type, then upload dump should work for any new unknown types, assuming the dump size doesn't overlap with an existing card type anyway).

This doesn't add support for dumping the LOCLASS attack data from the ICLASS_DETECTION mode, but I suspect this change alone is useful enough to be merged in going by the number of people in the discord checking out the iClass support in the RRG firmware repo.